### PR TITLE
Allow filtering of log messages before publishing

### DIFF
--- a/cmd/loglet/options/options.go
+++ b/cmd/loglet/options/options.go
@@ -17,6 +17,8 @@ type Loglet struct {
 	MaxMessageCount int
 	DefaultFields   map[string]string
 	LogLevel        log.Level
+	IncludeFilters  []string
+	ExcludeFilters  []string
 
 	// testing/debugging
 	FakeKafka  bool
@@ -52,6 +54,8 @@ func (l *Loglet) AddFlags() {
 	kingpin.Flag("cursor-file", "File in which to keep cursor state between runs").Default(l.CursorFile).StringVar(&l.CursorFile)
 	kingpin.Flag("default-field", "Default fields to add to all log entries. Values of fields in messages take precedence").StringMapVar(&l.DefaultFields)
 	kingpin.Flag("log-level", "Log level").Default(l.LogLevel.String()).SetValue(&LogLevelValue{&l.LogLevel})
+	kingpin.Flag("include-filter", "Include entries with a matching key value pair in the fields, combines as OR. Format: Key=Value").StringsVar(&l.IncludeFilters)
+	kingpin.Flag("exclude-filter", "Exclude entries with a matching key value pair in the fields, combines as OR. Format: Key=Value").StringsVar(&l.ExcludeFilters)
 
 	// TODO: might resurrect these if switching to AsyncProducer
 	// kingpin.Flag("max-message-delay", "The maximum time to buffer messages before sending to ES.").Default(l.MaxMessageDelay.String()).DurationVar(&l.MaxMessageDelay)

--- a/filter.go
+++ b/filter.go
@@ -1,0 +1,123 @@
+package loglet
+
+import (
+	"fmt"
+	"regexp"
+
+	log "github.com/Sirupsen/logrus"
+
+	"github.com/uswitch/loglet/cmd/loglet/options"
+)
+
+type JournalEntryFilter interface {
+	Ret() <-chan error
+	Entries() <-chan *JournalEntry
+}
+
+type journalEntryFilter struct {
+	ret             chan error
+	entries         chan *JournalEntry
+	includeFilters map[string]string
+	excludeFilters map[string]string
+}
+
+func NewJournalEntryFilter(loglet *options.Loglet, unfilteredEntries <-chan *JournalEntry, done <-chan struct{}) (JournalEntryFilter, error) {
+	ret := make(chan error, 2)
+	filteredEntries := make(chan *JournalEntry)
+
+	includeFilters, err := parseFilters(loglet.IncludeFilters)
+	if err != nil {
+		return nil, err
+	}
+
+	excludeFilters, err := parseFilters(loglet.ExcludeFilters)
+	if err != nil {
+		return nil, err
+	}
+
+	filter := &journalEntryFilter{
+		ret:             ret,
+		entries:         filteredEntries,
+		includeFilters: includeFilters,
+		excludeFilters: excludeFilters,
+	}
+
+	log.Info(includeFilters)
+	log.Info(excludeFilters)
+
+	go filter.start(unfilteredEntries, done)
+
+	return filter, nil
+}
+
+func (j *journalEntryFilter) Ret() <-chan error {
+	return j.ret
+}
+
+func (j *journalEntryFilter) Entries() <-chan *JournalEntry {
+	return j.entries
+}
+
+func (j *journalEntryFilter) start(unfilteredEntries <-chan *JournalEntry, done <-chan struct{}) {
+	defer close(j.ret)
+	defer close(j.entries)
+
+	for {
+		var entry *JournalEntry
+
+		select {
+		case <-done:
+			return
+		case entry = <-unfilteredEntries:
+			if entry == nil {
+				return
+			}
+		}
+
+		// if there are any include filters then an entry has to match at least one,
+		// however there need to be exclude filters before a match will exclude a message
+		included := len(j.includeFilters) == 0 || matchesFilters(j.includeFilters, entry.Fields)
+		excluded := len(j.excludeFilters) > 0 && matchesFilters(j.excludeFilters, entry.Fields)
+
+		if included && !excluded {
+			select {
+			case <-done:
+				return
+			case j.entries <- entry:
+				continue
+			}
+		}
+	}
+}
+
+var filterRe = regexp.MustCompile("^([^=]+)=([^=]+)$")
+
+func parseFilters(rawFilters []string) (map[string]string, error) {
+	filters := make(map[string]string)
+
+	for _, rawFilter := range rawFilters {
+		matches := filterRe.FindStringSubmatch(rawFilter)
+
+		log.Infof("%q %q %d", rawFilter, matches, len(matches))
+
+		if len(matches) == 0 {
+			return nil, fmt.Errorf("'%s' doesn't match expected pattern Key=Value", rawFilter)
+		} else {
+			filters[matches[1]] = matches[2]
+		}
+	}
+
+	return filters, nil
+}
+
+func matchesFilters(filters map[string]string, fields map[string]string) bool {
+	for k, filterValue := range filters {
+		fieldValue, ok := fields[k]
+
+		if ok && fieldValue == filterValue {
+			return true
+		}
+	}
+
+	return false
+}


### PR DESCRIPTION
We want to be able to send a subset of all journald messages off to a
different Kafka topic to all other messages. In order to select these
messages we want to be able to filter messages based on values in a
field.

For example if we want only STDOUT from a container with a docker label
of application=nginxlb, we can do the following:

```
loglet --include-filter APPLICATION=nginxlb,PRIORITY=6
```

\*journald will capitalize all fields.

At the moment this only does exact matching.